### PR TITLE
WIP (Request for comments) Relay one post's content; fallback to description

### DIFF
--- a/feed2maildir/converter.py
+++ b/feed2maildir/converter.py
@@ -179,19 +179,26 @@ Content-Type: text/plain
                 except:
                     sys.exit('ERROR: accessing "{}" failed'.format(fullname))
 
+    def post_description(self, post):
+        try:
+            return post.content[0].value
+        except:
+            return post.description
+
+
     def compose(self, title, post):
         """Compose the mail using the tempate"""
         try: # to get the update/publish time from the post
             updated = post.updated
         except: # the property is not set, use now()
             updated = datetime.datetime.now()
+
         desc = ''
         if not self.links:
+            desc = self.post_description(post)
             if self.strip:
-                self.stripper.feed(post.description)
+                self.stripper.feed(desc)
                 desc = self.stripper.get_data()
-            else:
-                desc = post.description
         return self.TEMPLATE.format(updated, post.title, title, post.link,
                                     desc)
 


### PR DESCRIPTION
### Problem:
`post.description` sometime returns only a summary. 

### Proposed solution:
In order to get the full description we read `post.content[0].value` and we fallback to `post.description` if the
former does not exist.

### Request for comments:
I couldn't figure out why the posts of some feeds only give me a summary when I call `post.description`. It happen with RSS and Atom feeds.

Using  `post.content[0].value` is a hack:
 - I arbitrary pick the first of `content`: could we select one based on the `type`?
 - Could we use other thing instead of `post.content`?

The change will not be backward compatible so probably we should add a flag in the command line or something similar and enable this feature/workaround/hack optionally.

This PR is obviously a work in progress.