### PR TITLE
Fetch and parse feeds in parallel using threads

### DIFF
--- a/feed2maildir/reader.py
+++ b/feed2maildir/reader.py
@@ -1,18 +1,23 @@
 import feedparser
+from multiprocessing.pool import ThreadPool
+
+def fetch_and_parse_feed(args):
+    name, feed = args
+    return (name, feedparser.parse(feed))
 
 class Reader:
     """Get updates on the feeds supplied"""
 
-    def __init__(self, feeds, silent=False):
+    def __init__(self, feeds, silent=False, njobs=4):
         self.feeds = []
         self.silent = silent
-        for feed in feeds:
-            f = feedparser.parse(feeds[feed])
-            if f.bozo:
-                self.output('WARNING: could not parse feed {}'.format(feed))
-            else:
-                f.feed_alias_name = feed # user provided text
-                self.feeds.append(f)
+        with ThreadPool(processes=njobs) as pool:
+            for feed, f in pool.imap_unordered(fetch_and_parse_feed, feeds.items()):
+                if f.bozo:
+                    self.output('WARNING: could not parse feed {}'.format(feed))
+                else:
+                    f.feed_alias_name = feed # user provided text
+                    self.feeds.append(f)
 
     def output(self, arg):
         if not self.silent:


### PR DESCRIPTION
Setup a thread pool of 4 threads (by default) to fetch and parse the
feeds in parallel.

In my personal setup I have 23 feeds and it takes to fetch and parse
them in sequence around 24 secs. With the thread pool of 4 threads the
time was reduced to 8 secs.

The speedup will vary but the experiment shown that `feedparser` is IO
bound so the use of threads will improve the overall performance.

Closes #12